### PR TITLE
virtio-mem: enable virtio-mem for arm64 in Kconfig

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -87,7 +87,7 @@ config VIRTIO_BALLOON
 config VIRTIO_MEM
 	tristate "Virtio mem driver"
 	default m
-	depends on X86_64
+	depends on X86_64 || ARM64
 	depends on VIRTIO
 	depends on MEMORY_HOTPLUG_SPARSE
 	depends on MEMORY_HOTREMOVE


### PR DESCRIPTION
virtio-mem works on arm64, so enable it in Kconfig.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@sboeuf @rbradford 
cc @MrXinWang @michael2012z 