### PR TITLE
arm64/mm: fix hotadd memory crash bug when racing for 'fixmap' with kernel_init

### DIFF
--- a/arch/arm64/mm/mmu.c
+++ b/arch/arm64/mm/mmu.c
@@ -63,6 +63,7 @@ static pmd_t bm_pmd[PTRS_PER_PMD] __page_aligned_bss __maybe_unused;
 static pud_t bm_pud[PTRS_PER_PUD] __page_aligned_bss __maybe_unused;
 
 static DEFINE_SPINLOCK(swapper_pgdir_lock);
+static DEFINE_SPINLOCK(fixmap_lock);
 
 void set_swapper_pgd(pgd_t *pgdp, pgd_t pgd)
 {
@@ -328,6 +329,11 @@ static void alloc_init_pud(pgd_t *pgdp, unsigned long addr, unsigned long end,
 	}
 	BUG_ON(p4d_bad(p4d));
 
+	/*
+	 * We only have one fixmap entry per page-table level, so take
+	 * the fixmap lock until we're done.
+	 */
+	spin_lock(&fixmap_lock);
 	pudp = pud_set_fixmap_offset(p4dp, addr);
 	do {
 		pud_t old_pud = READ_ONCE(*pudp);
@@ -358,6 +364,7 @@ static void alloc_init_pud(pgd_t *pgdp, unsigned long addr, unsigned long end,
 	} while (pudp++, addr = next, addr != end);
 
 	pud_clear_fixmap();
+	spin_unlock(&fixmap_lock);
 }
 
 static void __create_pgd_mapping(pgd_t *pgdir, phys_addr_t phys,


### PR DESCRIPTION
On arm64 side, memory hotplug may crash when hotadd memory during kernel_init, as both of them will call alloc_init_pud where fixmap will be used. But the 'fixmap' is global resource and can't used concurrently.
This patch has been accept by linux upstream, thus, port it here. 
See https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git/commit/?id=a6a6b9aa34e5

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@michael2012z @MrXinWang @rbradford 