### PR TITLE
init/main: Add trace points for logging boot time on x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Contains patches for:
 * virtio-iommu from https://jpbrucker.net/git/linux/log/?h=virtio-iommu/acpi (7616abe11cd1e0224bbd150626564db70bb07c31)
 * Support for virtio-watchdog
 * Bug fix: to support using ACPI reboot rather than EFI reboot
-
+* Log boot time via debug port `0x80` on x86 (details: https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/debug-port.md)

--- a/init/main.c
+++ b/init/main.c
@@ -935,6 +935,10 @@ asmlinkage __visible void __init __no_sanitize_address start_kernel(void)
 	char *command_line;
 	char *after_dashes;
 
+#ifdef CONFIG_X86
+	outb(0x40, 0x80);
+#endif
+
 	set_task_stack_end_magic(&init_task);
 	smp_setup_processor_id();
 	debug_objects_early_init();
@@ -1527,6 +1531,10 @@ static int __ref kernel_init(void *unused)
 	rcu_end_inkernel_boot();
 
 	do_sysctl_args();
+
+#ifdef CONFIG_X86
+	outb(0x41, 0x80);
+#endif
 
 	if (ramdisk_execute_command) {
 		ret = run_init_process(ramdisk_execute_command);


### PR DESCRIPTION
Use debug I/O port `0x80` to log boot time for Cloud Hypervisor.
Details: https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/docs/debug-port.md

Signed-off-by: Bo Chen <chen.bo@intel.com>