### PR TITLE
Debug: enable kernel boot up time measurement

### DIFF
--- a/arch/arm64/kernel/head.S
+++ b/arch/arm64/kernel/head.S
@@ -89,6 +89,7 @@
 	 *  x24        __primary_switch() .. relocate_kernel()  current RELR displacement
 	 */
 SYM_CODE_START(primary_entry)
+	bl	trap_to_vmm
 	bl	preserve_boot_args
 	bl	init_kernel_el			// w0=cpu_boot_mode
 	adrp	x23, __PHYS_OFFSET
@@ -104,6 +105,21 @@ SYM_CODE_START(primary_entry)
 	bl	__cpu_setup			// initialise processor
 	b	__primary_switch
 SYM_CODE_END(primary_entry)
+
+/*
+ * By writing to mmio region, trap to vmm to print timestamp,
+ * but corrupt x7 and x8.
+ * 0x9000f00 is debug region of pl011
+ * 0x40 is the code specified in cloud hypervisor indicating the first debug
+ * point of kernel.
+ */
+SYM_CODE_START(trap_to_vmm)
+	movz	x7, 0x0900, lsl 16
+	add	x7, x7, 0xf00
+	mov	x8, 0x40
+	str	w8, [x7]
+	ret
+SYM_CODE_END(trap_to_vmm)
 
 /*
  * Preserve the arguments passed by the bootloader in x0 .. x3

--- a/drivers/tty/serial/amba-pl011.c
+++ b/drivers/tty/serial/amba-pl011.c
@@ -44,6 +44,8 @@
 
 #include "amba-pl011.h"
 
+char __iomem *pl011_debug_addr;
+
 #define UART_NR			14
 
 #define SERIAL_AMBA_MAJOR	204
@@ -2751,6 +2753,9 @@ static int pl011_setup_port(struct device *dev, struct uart_amba_port *uap,
 	base = devm_ioremap_resource(dev, mmiobase);
 	if (IS_ERR(base))
 		return PTR_ERR(base);
+
+	pl011_debug_addr = (char __iomem *)base;
+	pl011_debug_addr += UART011_IO_DEBUG;
 
 	index = pl011_probe_dt_alias(index, dev);
 

--- a/include/linux/amba/serial.h
+++ b/include/linux/amba/serial.h
@@ -206,6 +206,8 @@
 #define UART01x_RSR_ANY		(UART01x_RSR_OE|UART01x_RSR_BE|UART01x_RSR_PE|UART01x_RSR_FE)
 #define UART01x_FR_MODEM_ANY	(UART01x_FR_DCD|UART01x_FR_DSR|UART01x_FR_CTS)
 
+#define UART011_IO_DEBUG	0xf00		/* used for debug I/O port emulation in VM */
+
 #ifndef __ASSEMBLY__
 struct amba_device; /* in uncompress this is included but amba/bus.h is not */
 struct amba_pl010_data {
@@ -224,5 +226,14 @@ struct amba_pl011_data {
 	void (*exit) (void);
 };
 #endif
+
+extern char __iomem *pl011_debug_addr;		/* save the pl011 debug mmio address, equal to base + UART011_IO_DEBUG */
+#define DEBUG_TRAP_VAL_END_BOOT 0x41		/* debug point at the end of kernel boot */
+
+/* wrapper of tricking pl011 debug */
+static inline void pl011_debug_trap(char val)
+{
+	writeb_relaxed(val, pl011_debug_addr);
+}
 
 #endif

--- a/init/main.c
+++ b/init/main.c
@@ -100,6 +100,7 @@
 #include <linux/kcsan.h>
 #include <linux/init_syscalls.h>
 #include <linux/stackdepot.h>
+#include <linux/amba/serial.h>
 
 #include <asm/io.h>
 #include <asm/bugs.h>
@@ -1534,6 +1535,10 @@ static int __ref kernel_init(void *unused)
 
 #ifdef CONFIG_X86
 	outb(0x41, 0x80);
+#endif
+
+#ifdef CONFIG_ARM64
+	pl011_debug_trap(DEBUG_TRAP_VAL_END_BOOT);
 #endif
 
 	if (ramdisk_execute_command) {


### PR DESCRIPTION
To measure kernel boot up time, reserved region in pl011 is used as trap
MMIO region to record kernel boot timestamp.
For now, we trap at 2 point: the first is nearly the first instruction of
kernel start; the second is just before call the init bin for userspace.
These 2 points can cover the whole kernel boot time.

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>